### PR TITLE
Add a Cake task for syncing assets to S3

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -1,10 +1,43 @@
 {spawn, exec} = require 'child_process'
 
+s3 = require('s3')
+
 runCommand = (name, args) ->
   proc =           spawn name, args
   proc.stderr.on   'data', (buffer) -> console.log buffer.toString()
   proc.stdout.on   'data', (buffer) -> console.log buffer.toString()
   proc.on          'exit', (status) -> process.exit(1) if status != 0
+
+uploadFile = (localFile, remoteFile, client) ->
+  uploader = client.upload(localFile, remoteFile)
+
+  uploader.on 'error', (err) ->
+    console.error 'unable to upload:', err.stack
+    process.exit(1)
+
+  uploader.on 'progress', () ->
+    console.log "uploading #{localFile}"
+
+  uploader.on 'end', ->
+    console.log 'done'
+    process.exit(0)
+
+task 'cut', 'Build and sync static files with S3', ->
+  unless process.env.S3_KEY and process.env.S3_SECRET and process.env.S3_BUCKET
+    console.error('! Set S3_KEY S3_SECRET and S3_BUCKET in your environment')
+    process.exit(1)
+
+  client = s3.createClient(
+    key: process.env.S3_KEY
+    secret: process.env.S3_SECRET
+    bucket: process.env.S3_BUCKET
+  )
+
+  runCommand 'stylus', ['--include', 'src', '--out', 'lib']
+  runCommand 'coffee', ['-c', '-o', 'lib', 'src']
+
+  uploadFile('lib/boomerang.css', 'boomerang/boomerang.css', client)
+  uploadFile('lib/boomerang.js', 'boomerang/boomerang.js', client)
 
 task 'dev', 'Watch source files and build JS & CSS', (options) ->
   runCommand 'http-server'

--- a/README.md
+++ b/README.md
@@ -38,11 +38,15 @@ manually:
 You'll need [node](http://nodejs.org/download/) to hack on this.
 
 ```bash
-[sudo] npm install -g stylus coffee-script http-server
+[sudo] npm install -g stylus coffee-script http-server s3
 brew install casperjs
+export S3_KEY='Amazon S3 Key'
+export S3_SECRET='Amazon S3 Secret'
+export S3_BUCKET='Amazon S3 Bucket'
 ```
 
 ```bash
+cake cut                # Build and sync static files with S3
 cake dev                # runs an http server and auto-compiles code changes
 cake test               # runs casperjs test suite
 ```


### PR DESCRIPTION
The task is called `cake cut` as in "cut a release" and whathaveyou. :cake:
- Requires the node package `s3` to be installed
- Requires you to set some environment variables for S3

I've updated the README accordingly.

The task currently assumes you'd like to upload `lib/boomerang.css` and `lib/boomerang.js`, but it could be made to accept arguments in the form of filenames or probably a pattern.
