### PR TITLE
Minor tweaks to help out.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
 S3_KEY=''
 S3_SECRET=''
+S3_BUCKET=''

--- a/Cakefile
+++ b/Cakefile
@@ -22,7 +22,7 @@ uploadFile = (localFile, remoteFile, callback) ->
   client = s3.createClient(
     key: process.env.S3_KEY
     secret: process.env.S3_SECRET
-    bucket: 'assets.heroku.com'
+    bucket: process.env.S3_BUCKET
   )
   
   # Make file are publicly visible

--- a/README.md
+++ b/README.md
@@ -57,9 +57,14 @@ You'll need [node](http://nodejs.org/download/) to hack on this.
 
 ```bash
 npm install
+```
+Be sure that ```./node_modules/.bin``` is in your path
+
+```bash
 brew install casperjs
 cp .env{.sample,}
 ```
+Edit .env and put in your S3_KEY, S3_SECRET and the S3_BUCKET from which you will serve your custom build
 
 ```bash
 foreman run cake cut    # Build and sync static files with S3

--- a/src/boomerang.coffee
+++ b/src/boomerang.coffee
@@ -47,7 +47,7 @@ class Boomerang
           <li class="big"><a href="http://#{@app}.herokuapp.com">#{@app}</a></li>
           <li class="sub"><a href="https://dashboard.heroku.com/apps/#{@app}/resources">Resources</a></li>
           <li class="sub"><a href="https://dashboard.heroku.com/apps/#{@app}/activity">Activity</a></li>
-          <li class="sub"><a href="https://dashboard.heroku.com/apps/#{@app}/collaborators">Collborators</a></li>
+          <li class="sub"><a href="https://dashboard.heroku.com/apps/#{@app}/collaborators">Collaborators</a></li>
           <li class="sub"><a href="https://dashboard.heroku.com/apps/#{@app}/settings">Settings</a></li>
             
           <li class="big"><a href="https://addons.heroku.com/#{@addon}">#{@addon}</a></li>


### PR DESCRIPTION
I needed to mess with this a bit and thought I'd commit a couple things that everyone might benefit from.
- fixed the misspelling in src that caused the compiled version to be wrong
- added the s3 bucket as a param so I could use my own s3 account from .env

Thought - Consider removing the style `body { padding 50px 10px 10px 10px; }` because it breaks anyone who is using a template with a relative-height page div like jQuery mobile's `<div id="page" data-role="..." >` or people with fixed footers.

If you want to not hide the top 32px maybe include adding a 32px div to the first element inside body or advise people to to it themselves.

If you want to keep that style maybe put it in the Readme as it is surprising for a plug-in to add css to the body tag.
