### PR TITLE
added ability to insert boomerang into a specific parent.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -17,10 +17,12 @@
 
   <h1>Boomerang Demo</h1>
 
+  <div id='boomerang-parent'></div>
   <ul class='demo_links'>
     <li><a href="#" class="a">Demo A</a></li>
     <li><a href="#" class="b">Demo B (with app and addon)</a></li>
     <li><a href="#" class="c">Demo C</a></li>
+    <li><a href="#" class="d">Demo D</a></li>
   </ul>
 
   <a href="#" onclick="Boomerang.reset();return false" class="reset">Reset</a>

--- a/lib/demo.js
+++ b/lib/demo.js
@@ -24,6 +24,14 @@
               addon: "honeybadger"
             });
           case "c":
+            var parent = document.getElementById('boomerang-parent');
+            return window.boomerang = new Boomerang({
+              parent: parent,
+              localMode: true,
+              app: "queriac",
+              addon: "honeybadger"
+            });
+          case "d":
             return window;
         }
       });

--- a/src/boomerang.coffee
+++ b/src/boomerang.coffee
@@ -15,6 +15,9 @@ class Boomerang
     @head = document.querySelector("head")
     @body = document.querySelector("body")
 
+    # a parent div to insert Boomerang into.
+    @parent = @options.parent || @body
+
     @attachStylesheet()
     @attachDiv()
 
@@ -64,7 +67,7 @@ class Boomerang
           <li><a href="https://help.heroku.com">Support</a></li>
         </ul>
       """
-    @body.appendChild(@div)
+    @parent.appendChild(@div)
 
   hideMenu: ->
     h = document.querySelector("#heroku-boomerang")

--- a/test/boomerang.spec.coffee
+++ b/test/boomerang.spec.coffee
@@ -14,6 +14,13 @@ casper.start "http://localhost:8080/demo.html", ->
   @waitUntilVisible "#boomerang", ->
     @test.assertExists ".boomerang > ul"
 
+  @click "a.reset"
+  @test.assertDoesntExist('#boomerang')
+
+  @click "a.c"
+  @waitUntilVisible "#boomerang", ->
+    @test.assertExists "#parent > .boomerang > ul"
+
 casper.run ->
   @test.done()
   @test.renderResults(true)


### PR DESCRIPTION
This allows for greater flexibility when positioning heroku navigation.

I added this because it uses `position: fixed` and inserts the boomerang into the bottom of the body. In my css I want to set position relative, and just have it rest nicely at the top of the page. It also allows for us to appropriately space our header when the boomerang is `position: relative`.
