### PR TITLE
Uses correct element ID in reset()

### DIFF
--- a/src/boomerang.coffee
+++ b/src/boomerang.coffee
@@ -82,7 +82,7 @@ class Boomerang
   # Remove boomerang and its event listeners.
   # (Used by demo and tests.)
   @reset: ->
-    h = document.getElementById('boomerang')
+    h = document.getElementById('heroku-boomerang')
     if h
       toggler = h.querySelector("a.toggler")
       toggler.removeEventListener('click', @toggleMenu) if toggler

--- a/test/boomerang.spec.coffee
+++ b/test/boomerang.spec.coffee
@@ -1,17 +1,17 @@
 casper.start "http://localhost:8080/demo.html", ->
 
   @click "a.reset"
-  @test.assertDoesntExist('#boomerang')
+  @test.assertDoesntExist('#heroku-boomerang')
     
   @click "a.a"
-  @waitUntilVisible "#boomerang", ->
+  @waitUntilVisible "#heroku-boomerang", ->
     @test.assertExists ".boomerang > ul"
 
   @click "a.reset"
-  @test.assertDoesntExist('#boomerang')
+  @test.assertDoesntExist('#heroku-boomerang')
   
   @click "a.b"
-  @waitUntilVisible "#boomerang", ->
+  @waitUntilVisible "#heroku-boomerang", ->
     @test.assertExists ".boomerang > ul"
 
 casper.run ->


### PR DESCRIPTION
The element ID in the `reset` method didn't match the ID of the element created by `init`. This means the reset method does not work.

I have a single page app and would like to remove the Boomerang toolbar once a user ends their session. But without the `reset` method, I need to fallback to modifying the DOM directly to remove the toolbar.